### PR TITLE
FIX : Handling rate limit from yfinance api 

### DIFF
--- a/indian_stocks.py
+++ b/indian_stocks.py
@@ -3,146 +3,125 @@ import streamlit as st
 import pandas as pd
 import plotly.express as px
 import os
-from datetime import datetime
+import time
 
-# Function to fetch stock data for US stocks
-def fetch_stock_data(ticker):
-    try:
-        if not ticker:
-            raise ValueError("Empty ticker symbol provided")
+# Cache to store stock data and prevent redundant requests
+cache = {}
 
-        stock = yf.Ticker(ticker)
-        
-        # Fetch historical data with validation
-        data = None
-        data_periods = ["1d", "1mo", "3mo"]
-        for period in data_periods:
-            data = stock.history(period=period)
-            if not data.empty:
-                break
-        
-        if data is None or data.empty:
-            raise ValueError(f"No historical data available for {ticker}")
+# Function to fetch multiple stock data at once
+def fetch_multiple_stocks(tickers, retries=3, delay=5):
+    global cache
+    tickers = list(set(tickers))  # Remove duplicates
+
+    # Check cache for previously fetched data
+    missing_tickers = [t for t in tickers if t not in cache]
+
+    if not missing_tickers:
+        return {t: cache[t] for t in tickers}
+
+    for attempt in range(retries):
+        try:
+            data = yf.download(missing_tickers, period="1mo")['Close']
             
-        # Get current price with explicit index handling
-        current_price = data['Close'].iloc[-1]
-        if pd.isnull(current_price):
-            raise ValueError("Invalid closing price received")
-            
-        # Get fundamental data with validation
-        info = stock.info
-        pe_ratio = info.get('trailingPE', 'N/A')
-        
-        return {
-            'current_price': current_price,
-            'pe_ratio': pe_ratio,
-            'error': None
-        }
-        
-    except Exception as e:
-        return {
-            'current_price': None,
-            'pe_ratio': None,
-            'error': f"Error fetching {ticker}: {str(e)}"
-        }
+            if data.empty:
+                raise ValueError("No historical data available")
 
+            latest_prices = data.iloc[-1].to_dict()
+
+            # Store fetched data in cache
+            for ticker, price in latest_prices.items():
+                cache[ticker] = {"current_price": price, "error": None}
+
+            return {t: cache[t] for t in tickers}
+
+        except Exception as e:
+            if "Too Many Requests" in str(e) and attempt < retries - 1:
+                st.warning(f"Rate limited. Retrying in {delay} seconds...")
+                time.sleep(delay)
+                delay *= 2  # Exponential backoff
+            else:
+                return {t: {"current_price": None, "error": str(e)} for t in tickers}
 
 # Function to calculate portfolio stats
 def calculate_portfolio(df):
+    tickers = df["Ticker"].str.strip().str.upper().tolist()
+    stock_data = fetch_multiple_stocks(tickers)
+
     total_value = 0
     valid_stocks = []
-    
+
     for index, row in df.iterrows():
-        ticker = row['Ticker'].strip().upper()
-        shares = float(row['Shares'])
-        avg_cost_basis = float(row['Avg. Cost Basis'])
-        
-        # Validate input values first
-        if not isinstance(shares, (int, float)) or shares <0:
-            st.error(f"Invalid shares value for {ticker}: {shares}")
+        ticker = row["Ticker"].strip().upper()
+        shares = float(row["Shares"])
+        avg_cost_basis = float(row["Avg. Cost Basis"])
+
+        if shares <= 0 or avg_cost_basis <= 0:
+            st.error(f"Invalid data for {ticker}: Shares {shares}, Cost {avg_cost_basis}")
             continue
-            
-        if not isinstance(avg_cost_basis, (int, float)) or avg_cost_basis <0:
-            st.error(f"Invalid cost basis for {ticker}: {avg_cost_basis}")
+
+        stock_info = stock_data.get(ticker, {})
+        current_price = stock_info.get("current_price")
+        error = stock_info.get("error")
+
+        if error:
+            st.error(f"Error fetching {ticker}: {error}")
             continue
-            
-        # Fetch stock data
-        stock_data = fetch_stock_data(ticker)
-        
-        if stock_data['error']:
-            st.error(stock_data['error'])
-            continue
-            
-        current_price = stock_data['current_price']
-        pe_ratio = stock_data['pe_ratio']
-        
-        if current_price > 0:
-            market_value = current_price * shares
-            return_percent = ((current_price - avg_cost_basis) / avg_cost_basis) * 100
-            total_value += market_value
-            
-            valid_stocks.append({
-                "Ticker": ticker,
-                "Shares": shares,
-                "Avg. Cost Basis": avg_cost_basis,
-                "Current Price": current_price,
-                "Market Value": market_value,
-                "Return (%)": return_percent,
-                "P/E Ratio": pe_ratio
-            })
-            
+
+        market_value = current_price * shares
+        return_percent = ((current_price - avg_cost_basis) / avg_cost_basis) * 100
+        total_value += market_value
+
+        valid_stocks.append({
+            "Ticker": ticker,
+            "Shares": shares,
+            "Avg. Cost Basis": avg_cost_basis,
+            "Current Price": current_price,
+            "Market Value": market_value,
+            "Return (%)": return_percent
+        })
+
     return valid_stocks, total_value
 
-# Function to plot interactive portfolio allocation
-def plot_portfolio(portfolio, title):
+# Function to plot portfolio allocation
+def plot_portfolio(portfolio):
     if not portfolio:
-        st.warning(f"No valid data to plot for {title}.")
+        st.warning("No valid data to plot.")
         return
-        
+    
     df = pd.DataFrame(portfolio)
-    
-    # Create two columns for better layout
+
     col1, col2 = st.columns(2)
-    
+
     with col1:
         st.subheader("Portfolio Holdings")
         st.dataframe(df.style.format({
-            'Current Price': 'INR {:.2f}',
-            'Market Value': 'INR {:.2f}',
-            'Return (%)': '{:.2f}%'
+            "Current Price": "INR {:.2f}",
+            "Market Value": "INR {:.2f}",
+            "Return (%)": "{:.2f}%"
         }))
-        
+
     with col2:
-        st.subheader(title)
-        fig = px.pie(
-            df,
-            values='Market Value',
-            names='Ticker',
-            hole=0.3,
-            labels={'Ticker': 'Ticker'},
-        )
-        fig.update_traces(textposition='inside', textinfo='percent+label')
+        st.subheader("Portfolio Allocation")
+        fig = px.pie(df, values="Market Value", names="Ticker", hole=0.3)
+        fig.update_traces(textposition="inside", textinfo="percent+label")
         st.plotly_chart(fig, use_container_width=True)
 
 # Main Function
 def main():
     st.title("Indian Portfolio Tracker")
 
-    # Path to the local CSV file
     file_path = os.path.join(os.getcwd(), "indian_portfolio.csv")
 
     try:
         df = pd.read_csv(file_path)
-        
-        # Validate CSV structure
-        required_columns = ['Ticker', 'Shares', 'Avg. Cost Basis']
+
+        required_columns = ["Ticker", "Shares", "Avg. Cost Basis"]
         if not all(col in df.columns for col in required_columns):
-            st.error(f"CSV has missing required columns. Needed: {required_columns}")
+            st.error(f"CSV missing required columns: {required_columns}")
             return
-            
-        # Clean data
-        df = df.dropna(subset=['Ticker'])
-        
+
+        df = df.dropna(subset=["Ticker"])
+
     except FileNotFoundError:
         st.error(f"Portfolio CSV file not found at {file_path}")
         return
@@ -150,20 +129,17 @@ def main():
         st.error(f"Error reading CSV file: {str(e)}")
         return
 
-    # Display raw data with toggle
     if st.checkbox("Show raw portfolio data"):
-        st.subheader("Raw Indian Portfolio Data")
+        st.subheader("Raw Portfolio Data")
         st.write(df)
 
-    # Calculate portfolio stats
     portfolio, total_value = calculate_portfolio(df)
 
-    # Display results
     if portfolio:
         st.success(f"Total Portfolio Value: INR {total_value:,.2f}")
-        plot_portfolio(portfolio, "Portfolio Allocation")
+        plot_portfolio(portfolio)
     else:
-        st.error("No valid stocks could be processed in the portfolio")
+        st.error("No valid stocks processed.")
 
 if __name__ == "__main__":
     main()

--- a/us_stocks.py
+++ b/us_stocks.py
@@ -3,146 +3,125 @@ import streamlit as st
 import pandas as pd
 import plotly.express as px
 import os
-from datetime import datetime
+import time
 
-# Function to fetch stock data for US stocks
-def fetch_stock_data(ticker):
-    try:
-        if not ticker:
-            raise ValueError("Empty ticker symbol provided")
+# Cache to store stock data and prevent redundant requests
+cache = {}
 
-        stock = yf.Ticker(ticker)
-        
-        # Fetch historical data with validation
-        data = None
-        data_periods = ["1d", "1mo", "3mo"]
-        for period in data_periods:
-            data = stock.history(period=period)
-            if not data.empty:
-                break
-        
-        if data is None or data.empty:
-            raise ValueError(f"No historical data available for {ticker}")
+# Function to fetch multiple stock data at once
+def fetch_multiple_stocks(tickers, retries=3, delay=5):
+    global cache
+    tickers = list(set(tickers))  # Remove duplicates
+
+    # Check cache for previously fetched data
+    missing_tickers = [t for t in tickers if t not in cache]
+
+    if not missing_tickers:
+        return {t: cache[t] for t in tickers}
+
+    for attempt in range(retries):
+        try:
+            data = yf.download(missing_tickers, period="1mo")['Close']
             
-        # Get current price with explicit index handling
-        current_price = data['Close'].iloc[-1]
-        if pd.isnull(current_price):
-            raise ValueError("Invalid closing price received")
-            
-        # Get fundamental data with validation
-        info = stock.info
-        pe_ratio = info.get('trailingPE', 'N/A')
-        
-        return {
-            'current_price': current_price,
-            'pe_ratio': pe_ratio,
-            'error': None
-        }
-        
-    except Exception as e:
-        return {
-            'current_price': None,
-            'pe_ratio': None,
-            'error': f"Error fetching {ticker}: {str(e)}"
-        }
+            if data.empty:
+                raise ValueError("No historical data available")
 
+            latest_prices = data.iloc[-1].to_dict()
+
+            # Store fetched data in cache
+            for ticker, price in latest_prices.items():
+                cache[ticker] = {"current_price": price, "error": None}
+
+            return {t: cache[t] for t in tickers}
+
+        except Exception as e:
+            if "Too Many Requests" in str(e) and attempt < retries - 1:
+                st.warning(f"Rate limited. Retrying in {delay} seconds...")
+                time.sleep(delay)
+                delay *= 2  # Exponential backoff
+            else:
+                return {t: {"current_price": None, "error": str(e)} for t in tickers}
 
 # Function to calculate portfolio stats
 def calculate_portfolio(df):
+    tickers = df["Ticker"].str.strip().str.upper().tolist()
+    stock_data = fetch_multiple_stocks(tickers)
+
     total_value = 0
     valid_stocks = []
-    
+
     for index, row in df.iterrows():
-        ticker = row['Ticker'].strip().upper()
-        shares = float(row['Shares'])
-        avg_cost_basis = float(row['Avg. Cost Basis'])
-        
-        # Validate input values first
-        if not isinstance(shares, (int, float)) or shares <0:
-            st.error(f"Invalid shares value for {ticker}: {shares}")
+        ticker = row["Ticker"].strip().upper()
+        shares = float(row["Shares"])
+        avg_cost_basis = float(row["Avg. Cost Basis"])
+
+        if shares <= 0 or avg_cost_basis <= 0:
+            st.error(f"Invalid data for {ticker}: Shares {shares}, Cost {avg_cost_basis}")
             continue
-            
-        if not isinstance(avg_cost_basis, (int, float)) or avg_cost_basis <0:
-            st.error(f"Invalid cost basis for {ticker}: {avg_cost_basis}")
+
+        stock_info = stock_data.get(ticker, {})
+        current_price = stock_info.get("current_price")
+        error = stock_info.get("error")
+
+        if error:
+            st.error(f"Error fetching {ticker}: {error}")
             continue
-            
-        # Fetch stock data
-        stock_data = fetch_stock_data(ticker)
-        
-        if stock_data['error']:
-            st.error(stock_data['error'])
-            continue
-            
-        current_price = stock_data['current_price']
-        pe_ratio = stock_data['pe_ratio']
-        
-        if current_price > 0:
-            market_value = current_price * shares
-            return_percent = ((current_price - avg_cost_basis) / avg_cost_basis) * 100
-            total_value += market_value
-            
-            valid_stocks.append({
-                "Ticker": ticker,
-                "Shares": shares,
-                "Avg. Cost Basis": avg_cost_basis,
-                "Current Price": current_price,
-                "Market Value": market_value,
-                "Return (%)": return_percent,
-                "P/E Ratio": pe_ratio
-            })
-            
+
+        market_value = current_price * shares
+        return_percent = ((current_price - avg_cost_basis) / avg_cost_basis) * 100
+        total_value += market_value
+
+        valid_stocks.append({
+            "Ticker": ticker,
+            "Shares": shares,
+            "Avg. Cost Basis": avg_cost_basis,
+            "Current Price": current_price,
+            "Market Value": market_value,
+            "Return (%)": return_percent
+        })
+
     return valid_stocks, total_value
 
-# Function to plot interactive portfolio allocation
-def plot_portfolio(portfolio, title):
+# Function to plot portfolio allocation
+def plot_portfolio(portfolio):
     if not portfolio:
-        st.warning(f"No valid data to plot for {title}.")
+        st.warning("No valid data to plot.")
         return
-        
+    
     df = pd.DataFrame(portfolio)
-    
-    # Create two columns for better layout
+
     col1, col2 = st.columns(2)
-    
+
     with col1:
         st.subheader("Portfolio Holdings")
         st.dataframe(df.style.format({
-            'Current Price': '${:.2f}',
-            'Market Value': '${:.2f}',
-            'Return (%)': '{:.2f}%'
+            "Current Price": "${:.2f}",
+            "Market Value": "${:.2f}",
+            "Return (%)": "{:.2f}%"
         }))
-        
+
     with col2:
-        st.subheader(title)
-        fig = px.pie(
-            df,
-            values='Market Value',
-            names='Ticker',
-            hole=0.3,
-            labels={'Ticker': 'Ticker'},
-        )
-        fig.update_traces(textposition='inside', textinfo='percent+label')
+        st.subheader("Portfolio Allocation")
+        fig = px.pie(df, values="Market Value", names="Ticker", hole=0.3)
+        fig.update_traces(textposition="inside", textinfo="percent+label")
         st.plotly_chart(fig, use_container_width=True)
 
 # Main Function
 def main():
     st.title("US Portfolio Tracker")
 
-    # Path to the local CSV file
     file_path = os.path.join(os.getcwd(), "us_portfolio.csv")
 
     try:
         df = pd.read_csv(file_path)
-        
-        # Validate CSV structure
-        required_columns = ['Ticker', 'Shares', 'Avg. Cost Basis']
+
+        required_columns = ["Ticker", "Shares", "Avg. Cost Basis"]
         if not all(col in df.columns for col in required_columns):
-            st.error(f"CSV has missing required columns. Needed: {required_columns}")
+            st.error(f"CSV missing required columns: {required_columns}")
             return
-            
-        # Clean data
-        df = df.dropna(subset=['Ticker'])
-        
+
+        df = df.dropna(subset=["Ticker"])
+
     except FileNotFoundError:
         st.error(f"Portfolio CSV file not found at {file_path}")
         return
@@ -150,20 +129,17 @@ def main():
         st.error(f"Error reading CSV file: {str(e)}")
         return
 
-    # Display raw data with toggle
     if st.checkbox("Show raw portfolio data"):
-        st.subheader("Raw US Portfolio Data")
+        st.subheader("Raw Portfolio Data")
         st.write(df)
 
-    # Calculate portfolio stats
     portfolio, total_value = calculate_portfolio(df)
 
-    # Display results
     if portfolio:
         st.success(f"Total Portfolio Value: ${total_value:,.2f}")
-        plot_portfolio(portfolio, "Portfolio Allocation")
+        plot_portfolio(portfolio)
     else:
-        st.error("No valid stocks could be processed in the portfolio")
+        st.error("No valid stocks processed.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
**Problem: Rate Limit Issue in yfinance**
The yfinance library has a strict rate limit when making API calls to fetch stock data. If too many requests are made in a short period, it results in an error like:
`HTTPError: 429 Too Many Requests`
This is because Yahoo Finance enforces request limits to prevent excessive traffic and we were making hitting everytime to fetch a stock details .

**Solution: Implementing Rate Limiting and Efficient Data Fetching**
To resolve this issue, we implemented the following changes across 3 py files:

1. Added Time-Based Rate Limiting:
- Introduced time.sleep() between API calls to ensure we stay within Yahoo Finance's request limits.
- This prevents hitting the 429 Too Many Requests error.
2. Batch Data Fetching:
- Instead of making multiple individual API calls, we used yfinance.download() to fetch stock data in bulk when possible.
- This significantly reduces the number of API  #requests.
3. Retry Mechanism:
- Implemented a retry mechanism using try-except to handle temporary failures.
- If a request fails due to rate limiting, the script waits for a few seconds and retries.



